### PR TITLE
Support multiple devices

### DIFF
--- a/src/battery.sh
+++ b/src/battery.sh
@@ -1,21 +1,68 @@
+#!/bin/bash
 SYSTEM_PROFILER=$(system_profiler SPBluetoothDataType 2>/dev/null)
-MAC_ADDRESS=$(grep -B8 "Minor Type: Headphones" <<< "${SYSTEM_PROFILER}" | awk '/Address/{ lastline = $2 } END { print lastline }')
-CONNECTED=$(grep -A10 "${MAC_ADDRESS}" <<< "${SYSTEM_PROFILER}" | awk '/Services:/{print 1}')
 
-if [[ "${CONNECTED}" ]]; then
-  CASE_BATTERY_LEVEL=$(grep -A6 "${MAC_ADDRESS}" <<< "${SYSTEM_PROFILER}" | awk '/Case Battery Level/{print $4}')
-  LEFT_BATTERY_LEVEL=$(grep -A6 "${MAC_ADDRESS}" <<< "${SYSTEM_PROFILER}" | awk '/Left Battery Level/{print $4}')
-  RIGHT_BATTERY_LEVEL=$(grep -A6 "${MAC_ADDRESS}" <<< "${SYSTEM_PROFILER}" | awk '/Right Battery Level/{print $4}')
-  battery="L: ${LEFT_BATTERY_LEVEL} R: ${RIGHT_BATTERY_LEVEL} C: ${CASE_BATTERY_LEVEL}"
+CONNECTED=$(awk '/  Connected:/{f=1;next} /Not Connected:/{f=0} f' <<< "${SYSTEM_PROFILER}" | grep -B4 "Battery Level:")
+
+print_device() {
+    # echo $device
+    if [ "$device" != "" ]; then
+        CASE_BATTERY_LEVEL=$(echo "${device}" | awk '/Case Battery Level/{print $4}')
+        LEFT_BATTERY_LEVEL=$(echo "${device}" | awk '/Left Battery Level/{print $4}')
+        RIGHT_BATTERY_LEVEL=$(echo "${device}" | awk '/Right Battery Level/{print $4}')
+        battery="🅛 ${LEFT_BATTERY_LEVEL} 🅡 ${RIGHT_BATTERY_LEVEL} | Case: ${CASE_BATTERY_LEVEL}"
+        if [[ "$LEFT_BATTERY_LEVEL" = "" && "$RIGHT_BATTERY_LEVEL" = ""  ]]; then
+            battery=$(echo "${device}" | awk '/Battery Level/{print $3}')
+        fi
+        if [[ "$battery" != "" ]]; then
+            ## customize the row as you wish
+            # echo "<item> <subtitle>$battery</subtitle> <title>$name</title> </item>"
+            # echo "<item> <title>$name $battery</title> </item>"
+            # echo "<item> <title>$battery - $name</title> </item>"
+            echo "<item> <title>$battery</title> <subtitle>$name</subtitle> </item>"
+        fi
+    fi
+}
+
+
+COUNT=$(echo $CONNECTED | grep -c "Vendor ID: 0x004C")
+
+if [[ "$COUNT" != "0"  ]]; then
+
+    echo "<?xml version='1.0' encoding='utf-8'?> <items>" # use XML as it will be easier to print logs to the output into alfred with echo
+
+    nl=$'\n'
+    name=""
+    device=""
+
+    CONNECTED="$CONNECTED$nl--" # append a separator to the end 
+
+    ## split CONNECTED into devices
+
+    echo "${CONNECTED}" | while read -r line
+    do 
+        if [ "$device" = "" ]
+            then
+            name=${line%?} # remove the colon: at the last place of device name
+            device="$line"
+        elif [ "$line" = "--" ]
+            then
+            print_device # print device battery in XML
+            device=""
+        else
+            echo $line
+            device="$device$nl$line" # append more lines to the device
+        fi
+    done
+
+    echo "</items>"
+
 else
-  battery="not connected"
-fi
-
 cat << EOB
-{"items": [
-    {
-        "uid": "battery",
-        "title": "$battery",
-    }
-]}
+    {"items": [
+        {
+            "uid": "battery",
+            "title": "not connected",
+        }
+    ]}
 EOB
+fi


### PR DESCRIPTION
- Support multiple unconnected/connected airpods
- Use Apple vendor id to support Beats products.
- Show battery for headphones like Airpods Max, Beats Studio³, etc.
- Use XML output to echo logs, and easier customize workflow items.

```
TEST_PROFILER="
Bluetooth:

      Bluetooth Controller:
          Address: 00:00:00:00:00:C6
          State: On
          Chipset: BCM_4364B3
          Discoverable: On
          Firmware Version: v86 c4205
          Product ID: 0x0001
          Supported services: 0x382039 < HFP AVRCP A2DP HID Braille AACP GATT Serial >
          Transport: UART
          Vendor ID: 0x004C (Apple)
      Connected:
          My AirPods3:
              Address: 00:00:00:00:00:F5
              Vendor ID: 0x004C
              Product ID: 0x2013
              Case Battery Level: 69%
              Left Battery Level: 89%
              Right Battery Level: 96%
              Firmware Version: 4E71
              Minor Type: Headphones
              Serial Number: 0000005
              Services: 0x980019 < HFP AVRCP A2DP AACP GATT ACL >
          My Beats Studio³:
              Address: 00:00:00:00:00:C7
              Vendor ID: 0x004C
              Product ID: 0x2009
              Battery Level: 100%
              Firmware Version: 2.4.4
              Minor Type: Headphones
              RSSI: -56
              Services: 0x880019 < HFP AVRCP A2DP AACP ACL >
          My AirPods Pro:
              Address: 00:00:00:00:00:13
              Vendor ID: 0x004C
              Product ID: 0x200E
              Case Battery Level: 99%
              Left Battery Level: 77%
              Right Battery Level: 82%
              Firmware Version: 4E71
              Minor Type: Headphones
              Serial Number: 000000T
              Services: 0x980019 < HFP AVRCP A2DP AACP GATT ACL >
          My AirPods Pro 2:
              Address: 00:00:00:00:34:46
              Vendor ID: 0x004C
              Product ID: 0x2014
              Case Battery Level: 42%
              Left Battery Level: 46%
              Right Battery Level: 53%
              Firmware Version: 5A377
              Minor Type: Headphones
              RSSI: -31
              Serial Number: 0000005
              Services: 0x980019 < HFP AVRCP A2DP AACP GATT ACL >
          Redmi K50:
              Address: 00:00:00:00:00:79
              Vendor ID: 0x038F
              Product ID: 0x1200
              Firmware Version: 20.3.6
              Minor Type: MobilePhone
              RSSI: -42
              Services: 0x902000 < Braille GATT ACL >
      Not Connected:
          2nd AirPods Pro:
              Address: 00:00:00:00:BD:08
              Vendor ID: 0x004C
              Product ID: 0x200E
              Firmware Version: 2D27
              Minor Type: Headphones
              Serial Number: 000000T
          My MacBook Pro:
              Address: 78:4F:43:8D:3E:DA
          My AirPods:
              Address: 00:00:00:00:17:F5
              Vendor ID: 0x004C
              Product ID: 0x2002
              Firmware Version: 6.8.8
              Minor Type: Headphones
              Serial Number: 000000TT
          MAJOR III BLUETOOTH:
              Address: 00:00:00:00:B4:13
              Minor Type: Headset"
```

<img width="727" alt="Screen Shot 2022-10-13 at 12 05 09" src="https://user-images.githubusercontent.com/6925920/195508540-70b9d32b-9c7e-49bb-80f6-3ba2b9ac0918.png">
